### PR TITLE
Add SCORM runtime service

### DIFF
--- a/internal/router/scorm_routes.go
+++ b/internal/router/scorm_routes.go
@@ -3,6 +3,7 @@ package router
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/guilherme-gatti/poc_scorm/internal/scorm"
+	"github.com/guilherme-gatti/poc_scorm/internal/scormrt"
 )
 
 func SetupScormRoutes(r *gin.Engine) {
@@ -18,4 +19,7 @@ func SetupScormRoutes(r *gin.Engine) {
 	r.GET("/courses/:id/view", scorm.GetCourseValidatedHandler)
 	r.POST("/courses/:id/validate", scorm.ValidateExistingCourseHandler)
 	r.DELETE("/courses/:id", scorm.DeleteCourseHandler)
+
+	// Runtime endpoint to communicate with external LMS
+	r.POST("/runtime", scormrt.RuntimeHandler)
 }

--- a/internal/scormrt/handler.go
+++ b/internal/scormrt/handler.go
@@ -1,0 +1,50 @@
+package scormrt
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RuntimeRequest represents a request to the runtime API.
+type RuntimeRequest struct {
+	Session string `json:"session"`
+	Method  string `json:"method"`
+	Element string `json:"element,omitempty"`
+	Value   string `json:"value,omitempty"`
+}
+
+// RuntimeHandler dispatches runtime API calls. The external LMS can POST a JSON
+// payload describing the method to invoke.
+func RuntimeHandler(c *gin.Context) {
+	var req RuntimeRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	var result interface{}
+	switch req.Method {
+	case "Initialize":
+		result = Initialize(req.Session)
+	case "Terminate":
+		result = Terminate(req.Session)
+	case "GetValue":
+		result = GetValue(req.Session, req.Element)
+	case "SetValue":
+		result = SetValue(req.Session, req.Element, req.Value)
+	case "Commit":
+		result = Commit(req.Session)
+	case "GetLastError":
+		result = GetLastError(req.Session)
+	case "GetErrorString":
+		result = GetErrorString(req.Value)
+	case "GetDiagnostic":
+		result = GetDiagnostic(req.Value)
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown method"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"result": result})
+}

--- a/internal/scormrt/service.go
+++ b/internal/scormrt/service.go
@@ -1,0 +1,121 @@
+package scormrt
+
+import (
+	"sync"
+)
+
+// RuntimeService holds runtime session data.
+type RuntimeService struct {
+	mu        sync.RWMutex
+	sessions  map[string]map[string]string
+	lastError map[string]string
+}
+
+// NewService creates a new RuntimeService.
+func NewService() *RuntimeService {
+	return &RuntimeService{
+		sessions:  make(map[string]map[string]string),
+		lastError: make(map[string]string),
+	}
+}
+
+var defaultService = NewService()
+
+// Initialize starts a new session for the given id.
+func (s *RuntimeService) Initialize(session string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.sessions[session]; !ok {
+		s.sessions[session] = make(map[string]string)
+	}
+	s.lastError[session] = "0"
+	return "true"
+}
+
+// Terminate ends an existing session.
+func (s *RuntimeService) Terminate(session string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, session)
+	s.lastError[session] = "0"
+	return "true"
+}
+
+// GetValue retrieves a value for an element.
+func (s *RuntimeService) GetValue(session, element string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if vals, ok := s.sessions[session]; ok {
+		if v, ok := vals[element]; ok {
+			s.lastError[session] = "0"
+			return v
+		}
+	}
+	s.lastError[session] = "101" // general error
+	return ""
+}
+
+// SetValue stores a value for an element.
+func (s *RuntimeService) SetValue(session, element, value string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.sessions[session]; !ok {
+		s.sessions[session] = make(map[string]string)
+	}
+	s.sessions[session][element] = value
+	s.lastError[session] = "0"
+	return "true"
+}
+
+// Commit would persist the session values. Here we simply acknowledge.
+func (s *RuntimeService) Commit(session string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.sessions[session]; ok {
+		s.lastError[session] = "0"
+		return "true"
+	}
+	s.lastError[session] = "101"
+	return "false"
+}
+
+// GetLastError returns the last error code for a session.
+func (s *RuntimeService) GetLastError(session string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if code, ok := s.lastError[session]; ok {
+		return code
+	}
+	return "0"
+}
+
+// GetErrorString maps error codes to messages.
+func (s *RuntimeService) GetErrorString(code string) string {
+	switch code {
+	case "0":
+		return "No error"
+	case "101":
+		return "General exception"
+	default:
+		return "Unknown error"
+	}
+}
+
+// GetDiagnostic returns diagnostic info for the code.
+func (s *RuntimeService) GetDiagnostic(code string) string {
+	return s.GetErrorString(code)
+}
+
+// exported helper functions using the default service
+func Initialize(session string) string { return defaultService.Initialize(session) }
+func Terminate(session string) string  { return defaultService.Terminate(session) }
+func GetValue(session, element string) string {
+	return defaultService.GetValue(session, element)
+}
+func SetValue(session, element, value string) string {
+	return defaultService.SetValue(session, element, value)
+}
+func Commit(session string) string       { return defaultService.Commit(session) }
+func GetLastError(session string) string { return defaultService.GetLastError(session) }
+func GetErrorString(code string) string  { return defaultService.GetErrorString(code) }
+func GetDiagnostic(code string) string   { return defaultService.GetDiagnostic(code) }


### PR DESCRIPTION
## Summary
- add `scormrt` package implementing SCORM runtime API
- expose `/runtime` route for external LMS
